### PR TITLE
Add examples/bash-harness/ and OPERATOR.md — production-grade bash harness

### DIFF
--- a/OPERATOR.md
+++ b/OPERATOR.md
@@ -1,0 +1,448 @@
+# Sandcastle Operator Guide
+
+This document is the production reference for operators running a Sandcastle
+bash harness. For the npm package overview and quick start, see `README.md`.
+
+The bash harness lives in `examples/bash-harness/` — copy it into your project
+as `.sandcastle/`.
+
+## File map
+
+| File | Purpose |
+|---|---|
+| `run.sh` | Host-side launcher. Pulls Claude OAuth from macOS Keychain, parses harness flags, invokes `main.ts`, runs allow-list + test gates after the run. |
+| `recover.sh` | Merges a `sandcastle-failed-*` backup branch back onto main with a mandatory `--note` for the audit trail. |
+| `queue.sh` | Runs Sandcastle sequentially against a list of issue numbers; prints a pass/fail summary at the end. |
+| `Dockerfile` | Image definition. Pre-bake your project's runtime dependencies (see the `PROJECT SETUP` comment block), plus Playwright + Chromium, and the `claude` shim. |
+| `claude-shim.sh` | Pinning shim that injects `--dangerously-skip-permissions` and the project MCP config when the in-container `claude` is invoked. |
+| `mcp-settings.json` | MCP server list available to the in-container agent (Playwright). |
+| `.env.example` | Template for `PROJECT_TEST_CMD` and `SANDCASTLE_AUTO_GENERATED_FILES`. Copy to `.env` and fill in. |
+| `logs/` | Per-run logs (stream-json, agent stdout, build, app). Bind-mounted from the worktree so they survive container teardown. |
+
+## Running
+
+A normal feature/bug issue:
+
+```bash
+# 1. Edit .sandcastle/prompt.md so the top `gh issue view <N>` line names
+#    the issue you want the agent to work on.
+# 2. Commit the prompt change.
+# 3. Fire it.
+./.sandcastle/run.sh
+```
+
+The launcher will:
+
+1. Pull a fresh Claude OAuth token from macOS Keychain.
+2. Snapshot the current HEAD.
+3. Detect the issue's labels (drives harness-change lifecycle, see below).
+4. Invoke `main.ts` (which builds the worktree and runs the agent in Docker).
+5. Retry up to 3 times on transient API/stream failures (no commits, no BLOCKED signal).
+6. After the agent's run finishes:
+   - Allow-list scope check (`## Allowed paths` from issue body).
+   - Required-artifacts gate (`## Required artifacts` from issue body).
+   - Host test gate (`$PROJECT_TEST_CMD` from `.env`).
+7. On success: leave main fast-forwarded onto the agent's commits; close the issue.
+8. On failure: capture worktree logs, preserve the agent's branch under a
+   `sandcastle-failed-*` prefix, reset main to its pre-run SHA.
+
+### Configuration
+
+Copy `.env.example` to `.env` in your repo root and set:
+
+```bash
+# Your project's test runner, evaluated with `eval` from repo root
+PROJECT_TEST_CMD=cd backend && .venv/bin/pytest tests/ -q
+
+# Space-separated auto-generated files that should always pass the allow-list gate
+SANDCASTLE_AUTO_GENERATED_FILES="frontend/src/routeTree.gen.ts"
+```
+
+### `onSandboxReady` hook
+
+To start your application inside the sandbox (so the agent can hit it via
+Playwright), add an `onSandboxReady` callback in your `main.ts`. Example
+pattern — run a script that boots your backend and frontend before the agent
+starts. See `main.ts.example` for the hook signature.
+
+## Orchestrator turn-end discipline (autonomous-loop mode)
+
+When Claude is driving Sandcastle unattended via `<<autonomous-loop-dynamic>>`
+(polling progress, deciding when to queue the next slice, reporting back),
+every turn MUST terminate in exactly one of two states:
+
+1. **Continue autonomously.** Call `ScheduleWakeup` for the next tick.
+   Do not ask the user a question in the user-facing text.
+2. **Hand back to the user.** State the specific blocker concretely
+   (the decision, mockup, credential, or scope choice only the user can
+   supply). Do NOT call `ScheduleWakeup`.
+
+The forbidden third state is ending the turn with no `ScheduleWakeup`
+**and** a question the orchestrator could have answered itself. The
+distinguishing test:
+
+- **Could the orchestrator reasonably pick either option and have the
+  user redirect on the next tick if they disagree?** Then the question
+  is a hidden stop. Pick, queue, continue. Do not ask.
+- **Is the choice genuinely the user's** (scope, policy, preference,
+  reservation of HITL work, two materially different directions)?
+  Then it's a real fork. Hand back, and phrasing the blocker as a
+  concrete question with the offered options is fine — that's clearer
+  than a flat statement. The marker is no `ScheduleWakeup`.
+
+The failure mode this rule blocks is the first kind: "want me to keep
+going on the visual-parity slices, or pause for review?" — both options
+were reasonable, the orchestrator could have picked, the question
+surrendered control. Compare with: "design-system doc could go in
+user-global config or project config, tradeoff is reach-vs-scope —
+which?" — this is the user's policy call, not the orchestrator's.
+
+### When to choose continue
+- `afk-ready` issues remain in the queue and their dependencies are met.
+- A long-running process is pending (Sandcastle run, build, test).
+- The next step is mechanical (verify a finished run, summarise, report).
+
+If you find yourself wanting to ask "should I keep going?", you are NOT
+blocked — choose continue, queue the next slice, and let the user
+redirect on the next tick if they disagree.
+
+### When to choose hand-back
+- A direction not previously approved (e.g. starting a new PRD, picking
+  between materially different design options).
+- An action with high blast radius the user hasn't authorised in this
+  session (`git push`, mass issue close, force-push, dependency bumps).
+- A decision the user has been deliberately reserving (HITL slices,
+  mockup approvals).
+- The `afk-ready` queue is empty or only HITL items remain.
+- **An agent-authored artifact gates a cascade and the user hasn't
+  reviewed it yet.** Design docs, schemas, contracts, and taste-laden
+  patterns produced by the inner Sandcastle agent often gate >1
+  downstream slice (whose ACs say "match this artifact"). If the user
+  has not seen the gating artifact, surface it for review before
+  cascading — a flawed gate replicated across N slices is dramatically
+  more expensive to fix than a single review pass now. Frame it as a
+  genuine fork: "review first" vs "trust-and-cascade", with the
+  artifact path and the dependent slice list named explicitly.
+
+When handing back, state the blocker concretely. If there are 2–3
+reasonable options the user owns the choice between, list them — that
+is clearer than a flat "blocked." Either way, do not call
+`ScheduleWakeup`; the next user turn re-engages the loop on its own
+terms.
+
+### Editing this policy
+
+This is the single control point for autonomous turn-end behaviour.
+Tighten it (e.g. require explicit approval before queueing each slice)
+or loosen it (e.g. permit `git push` when 20+ commits accumulate) by
+editing the bullets above. The orchestrator reads `.sandcastle/README.md`
+(or `OPERATOR.md`) during long Sandcastle work, so changes take effect
+on the next turn.
+
+## Harness-change two-phase lifecycle
+
+Harness changes — anything modifying `.sandcastle/**` — cannot self-verify
+within the run that produces them: the version of `run.sh` / `prompt.md` /
+`main.ts` driving the agent is the version *before* the agent's edit. A broken
+harness only manifests on the *next* invocation.
+
+To prevent broken harness changes from auto-merging into `main`, those
+issues follow a two-phase commit lifecycle.
+
+### Detection
+
+The launcher uses a single signal: the issue is labelled `harness-change`.
+
+### Phase 1 — hold
+
+When `run.sh` detects the `harness-change` label:
+
+- It generates a held branch name `sandcastle-harness-pending-<ts>`.
+- It exports `SANDCASTLE_HARNESS_PENDING_BRANCH=<name>`. `main.ts` reads this
+  and sets Sandcastle's `branchStrategy` to `branch` mode (instead of
+  `merge-to-head`), so Sandcastle creates the branch but does not
+  fast-forward the host's current branch.
+- After the gates pass, `run.sh` prints a "HELD" banner with the validation
+  command and exits 0.
+
+`main` HEAD does not move. The held branch sits in the local repo until
+the operator validates it.
+
+### Phase 2 — validate
+
+The operator validates by re-running Sandcastle with the held branch
+checked out as the launcher base, against a benign feature issue:
+
+```bash
+# 1. Retarget .sandcastle/prompt.md at a benign feature issue (the
+#    harness-change issue is already closed, so this must be a different
+#    issue — typically the next feature in the queue).
+# 2. Commit the prompt change (commit lands on main).
+# 3. Run validation:
+./.sandcastle/run.sh --harness-branch sandcastle-harness-pending-<ts>
+```
+
+The launcher will:
+
+1. `git checkout sandcastle-harness-pending-<ts>` (worktree's current HEAD
+   is now the held branch — the agent runs under the new harness code).
+2. Run the agent against the feature issue. Sandcastle's merge-to-head
+   merges the agent's commits onto the held branch.
+3. Run the allow-list + test gates against the resulting tree.
+4. On success: `git checkout main && git merge --ff-only <held-branch>`.
+   Both the harness change and the validation feature work ship into
+   `main` together. The held branch is deleted.
+5. On failure: leave the operator on `main` with the held branch
+   preserved under `sandcastle-failed-*-<ts>` so the operator can inspect
+   what broke.
+
+Two runs and a passing feature-validation are the only honest verification
+that the new harness code actually works.
+
+### Dockerfile-touched harness changes
+
+The image used by the validation run is whatever was last built. If the
+held branch's diff includes `.sandcastle/Dockerfile`, that change is NOT
+exercised by the validation run unless the operator rebuilds the image
+first:
+
+```bash
+docker build -f .sandcastle/Dockerfile -t <your-image-name> .
+```
+
+Then run `--harness-branch <name>` as above.
+
+For purely host-side harness changes (`run.sh`, `prompt.md`, `main.ts`),
+no rebuild is needed — the worktree files are read live.
+
+### Held-branch hygiene
+
+Held branches are the operator's responsibility. There is no auto-prune
+or accumulation warning. Two things to watch for:
+
+- A held branch from weeks ago may conflict with current `main` when the
+  validation tries to fast-forward. Resolve by rebasing the held branch
+  onto current `main` before validating, or abandon it and file a fresh
+  harness-change issue.
+- Multiple held branches in flight are unsupported. Validate one at a
+  time; back-to-back harness changes should be sequenced.
+
+## Allow-list scope check
+
+Every issue body must include an `## Allowed paths` section listing
+glob patterns the agent is permitted to touch. `run.sh` parses the
+section, computes `git diff <merge-base>..<work-branch> -- :(glob)<patterns>`,
+and rejects diffs touching files outside the list.
+
+### Issue body convention
+
+```markdown
+## Allowed paths
+
+\`\`\`
+backend/app/api/v1/some_endpoint.py
+backend/tests/test_some_endpoint.py
+frontend/src/routes/some-page.tsx
+\`\`\`
+```
+
+Glob patterns are supported (e.g. `backend/app/**`). Literal paths (no
+wildcards) trigger a pre-flight check: the parent directory must exist
+before the run. The file itself may be new (slices that legitimately
+create files are allowed), but the directory anchor must be real — this
+catches typo'd paths before the run.
+
+### Auto-allowed files
+
+Files listed in `SANDCASTLE_AUTO_GENERATED_FILES` (in `.env`) are
+unconditionally added to the allow-list pathspec for every issue. Use
+this for files that build tooling regenerates on every build regardless
+of what the agent touched (e.g. a router's generated route-tree file).
+
+Files declared in `## Required artifacts` are also auto-whitelisted
+(the two gates must not conflict).
+
+### Strictness for `afk-ready` issues
+
+If an issue is labelled `afk-ready` and its body has no
+`## Allowed paths` section, `run.sh` aborts after the agent's run
+(commits preserved on `sandcastle-failed-no-allowlist-<ts>`) instead
+of silent-skipping the gate.
+
+Issues without the `afk-ready` label keep warn-and-skip behaviour.
+
+## Required-artifacts gate
+
+Some ACs require fail-first evidence ("revert the fix, run the new test,
+see it fail"). Without a check, the agent can skip the cycle and the harness
+can't tell. The required-artifact gate forces the agent to commit a named
+evidence file per declared AC and rejects runs that don't.
+
+### How it works
+
+1. The issue body's `## Required artifacts` section lists filenames inside a
+   fenced code block (same convention as `## Allowed paths`).
+2. The agent writes evidence to `.sandcastle/artifacts/<name>` and commits it
+   alongside its code commit.
+3. After the agent commits, `run.sh` parses the section and runs
+   `git cat-file -s <work-branch>:.sandcastle/artifacts/<name>` for each
+   declared file. Size 0 (missing or empty) → BLOCK + revert.
+
+### Issue body convention
+
+```markdown
+## Required artifacts
+
+\`\`\`
+failing-test-output.txt
+before-screenshot.png
+\`\`\`
+```
+
+Leave the fenced block empty to declare the section but skip the gate
+(templates seed the section empty by default for issues with no
+fail-first ACs).
+
+### What the gate does and does NOT prove
+
+- Does prove: the agent physically wrote a non-empty file at the expected
+  path. Implies it had to think about the AC's evidence step.
+- Does NOT prove: the file's contents are real test output. `echo ok > file`
+  passes the gate.
+
+This is by design. The gate's value is audit-cost shifting — turning
+"invisible until manual transcript review" into "trivially spot-checkable
+in the worktree." Operators should still glance at artifact contents
+during review; the green gate is not a proof of correctness.
+
+### When to use it
+
+- Issues with fail-first regression ACs.
+- Harness self-tests where the AC requires producing a specific signal in a
+  log.
+
+When in doubt: leave the section's fenced block empty (silent-skip).
+
+## Failure recovery
+
+### `sandcastle-failed-*` backup branches
+
+When any gate (allow-list, required-artifacts, host tests) rejects a run,
+`run.sh`:
+
+1. Renames the agent's work branch (or creates a backup branch) as
+   `sandcastle-failed-<reason>-<ts>`.
+2. Resets `main` to its pre-run SHA.
+3. Copies agent worktree logs to `.sandcastle/logs/host-side-<ts>/`.
+4. Posts a structured diagnostic comment to the issue with the backup
+   branch name and a `recover.sh` command.
+5. Applies the `sandcastle-failed` label to the issue.
+
+The agent's work is never lost — it lives on the backup branch until
+the operator reviews it.
+
+### `recover.sh` — manual override
+
+When you have reviewed the diff and judged it correct:
+
+```bash
+./.sandcastle/recover.sh sandcastle-failed-<reason>-<ts> \
+  --note "<why this revert is being overridden>"
+```
+
+This:
+1. `git merge --no-ff <backup-branch>` onto main.
+2. Posts a recovery comment to the issue with the merge SHA and your note.
+3. Removes the `sandcastle-failed` label; adds `sandcastle-recovered`.
+4. Closes the issue.
+
+The `--note` argument is mandatory — it is the audit trail for every
+manual override. The backup branch is not deleted; it remains for
+historical inspection.
+
+Auto-detection reads the issue number from the `gh issue view <N>` line
+in `prompt.md`. Pass `--issue <N>` explicitly if that detection fails.
+
+### Issue lifecycle labels
+
+| Label | Meaning |
+|---|---|
+| `sandcastle-failed` | Run reverted by a host gate. Work is on a `sandcastle-failed-*` backup branch. |
+| `sandcastle-recovered` | Backup branch was manually merged via `recover.sh`. Issue closed by the wrapper. |
+
+Both labels are created idempotently by `run.sh` and `recover.sh` on first use.
+
+### Three layers of allow-list defence
+
+**Layer 1 — Agent Step 0 scope sanity check**
+
+Before the agent edits anything, your `prompt.md` can ask it to list all
+intended files and verify each one matches the issue's `## Allowed paths`
+block. If any file is out of scope, the agent posts a `BLOCKED:` comment
+naming the mismatch and stops without committing. This catches semantic
+mismatches — where the issue prose and the allow-list block disagree —
+before any work is done.
+
+**Layer 2 — Pre-flight literal-path parent-directory check**
+
+After the agent's run and before the diff is inspected, `run.sh` checks
+every literal path (non-glob) in `## Allowed paths` against the working
+tree. If any literal path's parent directory doesn't exist, the run calls
+`gate_revert_with_logs` and posts a diagnostic comment. The operator fixes
+the allow-list and can recover the work via `recover.sh` without
+re-running the agent.
+
+**Layer 3 — Revert-time diagnostic comment + label**
+
+When any gate reverts a run, `run.sh` posts a structured comment to the
+issue with the failure reason, the backup branch name, and the `recover.sh`
+command to merge the branch with an override note.
+
+## Queue
+
+Run Sandcastle against multiple issues back-to-back:
+
+```bash
+./.sandcastle/queue.sh <issue-number> [<issue-number> ...]
+# Example:
+./.sandcastle/queue.sh 20 19 9
+```
+
+`queue.sh`:
+1. Checks each issue is still OPEN before running (skips closed issues).
+2. `sed`-swaps `prompt.md` to target the issue and commits the swap.
+3. Calls `run.sh` (which has its own retry loop).
+4. Failures on one issue do not abort the queue.
+5. Prints a pass/fail/closed summary table at the end.
+
+## Per-run logs
+
+`logs/` (bind-mounted from the worktree) survives container teardown.
+On run failure, `run.sh` copies the agent worktree's logs out to
+`logs/host-side-<ts>/` for post-mortem.
+
+Files in a typical run:
+
+| Filename | Source |
+|---|---|
+| `main-<run-name>-<ts>.log` | Sandcastle's TS launcher stdout (stream-json, agent transcript) |
+| `host-test-<ts>.log` | Host test suite output from `run.sh`'s gate |
+| `host-side-<ts>/` | Agent worktree logs copied out on failure |
+
+## Troubleshooting
+
+- **"Could not read Claude OAuth credentials from macOS Keychain"** —
+  run `claude` once on the host to authenticate, then retry.
+- **"Uncommitted changes detected"** — Sandcastle's bind-mount would let
+  the agent see and possibly commit them. Stash or commit before retrying.
+- **"PROJECT_TEST_CMD is not set"** — set it in `.env` at the repo root
+  (see `.env.example`).
+- **Allow-list violation** — agent edited files outside the issue's
+  declared scope. The diff is preserved on `sandcastle-failed-allowlist-<ts>`
+  for inspection. Either narrow what the agent did (next iteration) or
+  expand the issue's `## Allowed paths` section if the change is
+  legitimately needed.
+- **`<promise>BLOCKED</promise>` in the run log** — agent voluntarily
+  aborted. Check the log for the reason.
+- **3 attempts produced no commits** — likely a transient API/stream
+  failure. The launcher gives up after 3 attempts; rerun manually.

--- a/examples/bash-harness/.env.example
+++ b/examples/bash-harness/.env.example
@@ -1,0 +1,12 @@
+# Project-specific test command. Evaluated with `eval` from REPO_ROOT.
+# Examples:
+#   PROJECT_TEST_CMD=cd backend && .venv/bin/pytest tests/ -q
+#   PROJECT_TEST_CMD=npm test
+#   PROJECT_TEST_CMD=make test
+PROJECT_TEST_CMD=
+
+# Space-separated list of auto-generated files that should always pass
+# the allow-list gate (relative to repo root). These are files that
+# tooling regenerates on every build regardless of what the agent touched.
+# Example: SANDCASTLE_AUTO_GENERATED_FILES="frontend/src/routeTree.gen.ts"
+SANDCASTLE_AUTO_GENERATED_FILES=

--- a/examples/bash-harness/Dockerfile
+++ b/examples/bash-harness/Dockerfile
@@ -1,0 +1,87 @@
+FROM node:22-bookworm
+
+# UID/GID for the in-container `agent` user. Sandcastle's docker provider
+# launches the container with `--user $hostUid:$hostGid` so bind-mounted files
+# match host ownership. Defaults match macOS dev convention (501:20). On Linux
+# hosts where `id -u` is 1000, override at build time:
+#   docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) ...
+ARG USER_UID=501
+ARG USER_GID=20
+
+# System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl jq \
+    ca-certificates gnupg \
+  && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (agent prompt uses `gh issue list`, `gh issue close`, etc.)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# chrome-devtools-mcp for Loop B (playwright-verify) on frontend AFK issues
+RUN npm install -g chrome-devtools-mcp@latest
+
+# Playwright + Chromium for in-sandbox UI verification (Loop B).
+# Adds ~700 MB. Image grows from ~2.6 GB to ~3.7 GB; acceptable.
+#
+# PLAYWRIGHT_BROWSERS_PATH is set globally so the install lands at a
+# world-readable path (default ~/.cache/ms-playwright is owned by root and
+# the agent user can't read it). The stable symlink decouples
+# @playwright/mcp's --executable-path from the chromium revision number.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
+RUN mkdir -p /opt/playwright-browsers \
+  && npm install -g @playwright/mcp@latest playwright@latest \
+  && npx --yes playwright install --with-deps chromium \
+  && ln -sf /opt/playwright-browsers/chromium-*/chrome-linux/chrome /usr/local/bin/playwright-chromium \
+  && chmod -R a+rX /opt/playwright-browsers
+
+# ── PROJECT SETUP — customise for your project ──────────────────────────────
+# Pre-bake your project's runtime dependencies here for faster sandbox startup.
+# Examples:
+#
+# Python (pip):
+#   COPY backend/pyproject.toml /tmp/project-build/pyproject.toml
+#   COPY backend/README.md /tmp/project-build/README.md
+#   RUN python3 -m venv /opt/project-venv \
+#     && /opt/project-venv/bin/pip install --upgrade pip --quiet \
+#     && /opt/project-venv/bin/pip install "/tmp/project-build[dev]" --quiet \
+#     && rm -rf /tmp/project-build
+#   ENV PATH="/opt/project-venv/bin:${PATH}"
+#
+# Node (npm):
+#   COPY package.json package-lock.json /tmp/project-frontend/
+#   RUN cd /tmp/project-frontend && npm ci --prefer-offline --no-audit \
+#     && mkdir -p /opt/project-deps \
+#     && mv /tmp/project-frontend/node_modules /opt/project-deps/node_modules \
+#     && rm -rf /tmp/project-frontend
+# ────────────────────────────────────────────────────────────────────────────
+
+# Rename the base image's "node" user AND group (UID/GID 1000) to "agent" and
+# renumber to USER_UID/USER_GID so it matches the host (Sandcastle runs the
+# container as the host UID). On macOS GID 20 ("dialout" in Debian) already
+# exists — delete the conflicting group first if so.
+RUN getent group ${USER_GID} | grep -qv "^agent:" && groupdel "$(getent group ${USER_GID} | cut -d: -f1)" || true \
+  && usermod -d /home/agent -m -l agent node \
+  && groupmod -n agent node \
+  && groupmod -g ${USER_GID} agent \
+  && usermod -u ${USER_UID} -g ${USER_GID} agent \
+  && chown -R agent:agent /home/agent
+
+USER agent
+
+# Install Claude Code CLI (per-user install — required because --dangerously-skip-permissions
+# refuses to run as root)
+COPY --chown=agent:agent .sandcastle/claude-shim.sh /home/agent/.local/bin/claude-shim.sh
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+  && mv /home/agent/.local/bin/claude /home/agent/.local/bin/claude-real \
+  && cp /home/agent/.local/bin/claude-shim.sh /home/agent/.local/bin/claude \
+  && chmod +x /home/agent/.local/bin/claude
+
+WORKDIR /home/agent
+
+# Sandcastle bind-mounts the git worktree at /home/agent/workspace at container start.
+ENTRYPOINT ["sleep", "infinity"]

--- a/examples/bash-harness/README.md
+++ b/examples/bash-harness/README.md
@@ -1,0 +1,14 @@
+# Bash Harness Example
+
+A production-grade operator harness for Sandcastle using bash.
+
+Copy this directory into your project as `.sandcastle/` and customise:
+1. Set `PROJECT_TEST_CMD` in `.env` (your project's test runner command).
+2. Set `SANDCASTLE_AUTO_GENERATED_FILES` in `.env` if your build regenerates
+   any files that should always pass the allow-list gate.
+3. Customise `Dockerfile` for your project's runtime dependencies
+   (see the `PROJECT SETUP` comment block).
+4. Rename `main.ts.example` to `main.ts` and fill in your docker image name.
+5. Edit `prompt.md` (create one) to target your first issue.
+
+See `OPERATOR.md` at the repository root for full operational documentation.

--- a/examples/bash-harness/claude-shim.sh
+++ b/examples/bash-harness/claude-shim.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+LOG=/home/agent/workspace/.sandcastle/logs/claude-mcp.log
+mkdir -p "$(dirname "$LOG")" 2>/dev/null || true
+exec /home/agent/.local/bin/claude-real \
+  --mcp-config /home/agent/workspace/.sandcastle/mcp-settings.json \
+  --strict-mcp-config \
+  --debug-file "$LOG" \
+  "$@"

--- a/examples/bash-harness/mcp-settings.json
+++ b/examples/bash-harness/mcp-settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp", "--executable-path", "/usr/local/bin/playwright-chromium", "--headless", "--user-data-dir", "/tmp/playwright-profile"]
+    }
+  }
+}

--- a/examples/bash-harness/queue.sh
+++ b/examples/bash-harness/queue.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Run Sandcastle sequentially against a list of issue numbers.
+# For each issue:
+#   1. sed-swap prompt.md to point at it
+#   2. commit the swap (Sandcastle's worktree is created from HEAD,
+#      so an uncommitted swap would not be visible to the agent)
+#   3. invoke .sandcastle/run.sh (which has its own retry loop for
+#      transient API/stream failures)
+# Failures on one issue do not abort the queue — the next issue runs
+# anyway. Final summary at the end.
+#
+# Run from repo root:
+#   ./.sandcastle/queue.sh 20 19 9
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <issue-number> [<issue-number> ...]" >&2
+  exit 2
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Error: working tree is dirty. Commit or stash before queue.sh." >&2
+  exit 1
+fi
+
+PROMPT_FILE=".sandcastle/prompt.md"
+declare -a RESULTS=()
+
+for issue in "$@"; do
+  if ! [[ "$issue" =~ ^[0-9]+$ ]]; then
+    echo "Skipping non-numeric arg: $issue" >&2
+    RESULTS+=("#${issue}: skipped (non-numeric)")
+    continue
+  fi
+
+  before=$(git rev-parse HEAD)
+  echo
+  echo "================================================================"
+  echo "==> Queue: targeting issue #${issue} (head=${before:0:10})"
+  echo "================================================================"
+
+  state=$(gh issue view "$issue" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+  if [ "$state" != "OPEN" ]; then
+    echo "==> Issue #${issue} is ${state}; skipping."
+    RESULTS+=("#${issue}: skipped (${state})")
+    continue
+  fi
+
+  sed -i.tmp -E "s|gh issue view [0-9]+|gh issue view ${issue}|" "$PROMPT_FILE"
+  rm -f "${PROMPT_FILE}.tmp"
+
+  if git diff --quiet "$PROMPT_FILE"; then
+    echo "==> prompt.md already targets #${issue}; no swap commit needed."
+  else
+    git add "$PROMPT_FILE"
+    # --no-verify is used only for this mechanical swap commit; the swap itself
+    # has no code changes and hooks would add noise without value here.
+    git commit -m "Sandcastle: target issue #${issue}" \
+      --no-verify >/dev/null
+    echo "==> Swap committed: $(git rev-parse --short HEAD)"
+  fi
+
+  set +e
+  ./.sandcastle/run.sh
+  rc=$?
+  set -e
+
+  after=$(git rev-parse HEAD)
+  if [ "$after" = "$before" ] || [ "$after" = "$(git rev-parse HEAD~0)" ]; then
+    : # no-op placeholder
+  fi
+
+  closed_at=$(gh issue view "$issue" --json closedAt --jq '.closedAt // ""' 2>/dev/null || echo "")
+  if [ -n "$closed_at" ]; then
+    RESULTS+=("#${issue}: CLOSED at ${closed_at} (rc=${rc})")
+  elif [ "$rc" -eq 0 ]; then
+    RESULTS+=("#${issue}: rc=0 but issue still OPEN — agent may have committed without closing")
+  else
+    RESULTS+=("#${issue}: FAILED (rc=${rc}) — issue still OPEN")
+  fi
+done
+
+echo
+echo "================================================================"
+echo "Queue complete."
+echo "================================================================"
+for line in "${RESULTS[@]}"; do
+  echo "  $line"
+done

--- a/examples/bash-harness/recover.sh
+++ b/examples/bash-harness/recover.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Recover work from a sandcastle-failed-* backup branch.
+# Records the override with a mandatory --note for audit-log purposes.
+# Adds sandcastle-recovered label, removes sandcastle-failed, closes the issue.
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <backup-branch> --note '<reason>' [--issue <number>]"
+    echo "  <backup-branch>   sandcastle-failed-* branch to merge"
+    echo "  --note '<reason>' mandatory free-form reason for overriding the revert"
+    echo "  --issue <num>     issue number; auto-detected from prompt.md if omitted"
+    exit 2
+}
+
+[ $# -lt 1 ] && usage
+backup_branch="$1"; shift
+
+note=""
+issue_num=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --note)  note="$2"; shift 2 ;;
+        --issue) issue_num="$2"; shift 2 ;;
+        *) usage ;;
+    esac
+done
+
+case "$backup_branch" in
+    sandcastle-failed-*) ;;
+    *) echo "Error: branch must start with 'sandcastle-failed-'" >&2; exit 1 ;;
+esac
+
+if [ -z "$note" ]; then
+    echo "Error: --note is mandatory. Why is this revert being overridden?" >&2
+    exit 1
+fi
+
+if ! git rev-parse --verify "$backup_branch" >/dev/null 2>&1; then
+    echo "Error: branch '$backup_branch' does not exist." >&2
+    exit 1
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "main" ]; then
+    echo "Error: must be run on 'main' (currently on '$current_branch')." >&2
+    echo "       Recovery merges the backup branch onto main; refusing to merge onto another branch." >&2
+    exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: working tree is dirty. Commit or stash before recovery." >&2
+    exit 1
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+if [ -z "$issue_num" ]; then
+    issue_num=$(grep -oE 'gh issue view [0-9]+' "$REPO_ROOT/.sandcastle/prompt.md" | head -1 | grep -oE '[0-9]+' || true)
+fi
+if [ -z "$issue_num" ]; then
+    echo "Error: could not auto-detect issue number; pass --issue <num>." >&2
+    exit 1
+fi
+
+gh label create sandcastle-failed --color "EE0000" --description "Sandcastle run reverted by host gate" 2>/dev/null || true
+gh label create sandcastle-recovered --color "0E8A16" --description "Sandcastle backup branch manually recovered via recover.sh" 2>/dev/null || true
+
+# Failure reason from branch suffix (allowlist, no-allowlist, artifacts, no-artifacts, preflight, test, ...).
+# Anchor on the trailing -YYYYMMDD-HHMMSS timestamp so hyphenated reasons survive intact.
+# Legacy branches without a reason segment fall back to "unknown".
+reason=$(echo "$backup_branch" | sed -E 's/^sandcastle-failed-(.+)-[0-9]{8}-[0-9]{6}$/\1/')
+if [ "$reason" = "$backup_branch" ]; then
+    reason="unknown"
+fi
+
+git merge --no-ff "$backup_branch" -m "Recover from $backup_branch ($reason): $note"
+recovered_sha=$(git rev-parse HEAD)
+
+gh issue comment "$issue_num" --body "$(cat <<EOF
+✅ **Recovered**: merged \`$recovered_sha\` from \`$backup_branch\`.
+**Original failure**: $reason
+**Reason for recovery**: $note
+EOF
+)"
+
+gh issue edit "$issue_num" --remove-label sandcastle-failed 2>/dev/null || true
+gh issue edit "$issue_num" --add-label sandcastle-recovered 2>/dev/null || true
+
+gh issue close "$issue_num" --comment "Closed by recover.sh: $recovered_sha"
+
+echo "==> Recovered: merged $backup_branch onto main as $recovered_sha"
+echo "    Issue #$issue_num: labelled sandcastle-recovered, closed."

--- a/examples/bash-harness/run.sh
+++ b/examples/bash-harness/run.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Sandcastle launcher — extracts the live Claude OAuth token from macOS
+# Keychain and exports it as CLAUDE_CODE_OAUTH_TOKEN so the in-container
+# `claude` CLI can authenticate with the host's subscription.
+#
+# The bind-mounted ~/.claude/.credentials.json file is unreliable on macOS:
+# Claude Code writes credentials to the Keychain, and the file on disk is
+# typically stale (the access token in it is expired). The env var path is
+# what the official `claude-sandbox.sh` uses and what we mirror here.
+#
+# Run from repo root:  ./.sandcastle/run.sh
+#                or:   bash .sandcastle/run.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+# Long-flag --harness-branch <name> activates validation mode: check out the
+# held branch, run the agent against it, fast-forward main on success.
+HARNESS_VALIDATE_BRANCH=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness-branch)
+            shift
+            [ -z "${1:-}" ] && { echo "Error: --harness-branch requires a value." >&2; exit 1; }
+            HARNESS_VALIDATE_BRANCH="$1"
+            shift
+            ;;
+        *)
+            echo "Error: unknown argument '$1'." >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v security >/dev/null 2>&1; then
+    echo "Error: 'security' command not found — this script requires macOS." >&2
+    exit 1
+fi
+
+raw_creds=$(security find-generic-password -s "Claude Code-credentials" -a "user" -w 2>/dev/null || true)
+if [ -z "$raw_creds" ]; then
+    echo "Error: Could not read Claude OAuth credentials from macOS Keychain." >&2
+    echo "       Run 'claude' once on the host to authenticate, then retry." >&2
+    exit 1
+fi
+
+token=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(d['claudeAiOauth']['accessToken'])" "$raw_creds" 2>/dev/null || true)
+if [ -z "$token" ]; then
+    echo "Error: Keychain entry exists but does not have the expected OAuth shape." >&2
+    exit 1
+fi
+
+export CLAUDE_CODE_OAUTH_TOKEN="$token"
+
+echo "==> Live OAuth token extracted from Keychain (length=${#token})."
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+before_head=$(git rev-parse HEAD)
+echo "==> Pre-run state: branch=${current_branch} head=${before_head:0:10}"
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: Uncommitted changes detected in the working tree." >&2
+    echo "       Sandcastle's bind-mount would let the agent see and possibly commit them." >&2
+    echo "       Stash or commit before retrying." >&2
+    exit 1
+fi
+
+# (feature gates added below)

--- a/examples/bash-harness/run.sh
+++ b/examples/bash-harness/run.sh
@@ -67,4 +67,155 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
     exit 1
 fi
 
-# (feature gates added below)
+
+# ── Harness lifecycle mode detection ─────────────────────────────────────────
+# Two scenarios:
+#   1. --harness-branch <name>: validation mode. Check out <name>, run agent
+#      against it; on success fast-forward main onto <name>.
+#   2. Issue labelled `harness-change`: hold mode. Land work on a holding
+#      branch instead of merging to main; operator validates later.
+HARNESS_HOLD_BRANCH=""
+HARNESS_MODE=""
+
+if [ -n "${HARNESS_VALIDATE_BRANCH}" ]; then
+    if ! git show-ref --verify --quiet "refs/heads/${HARNESS_VALIDATE_BRANCH}"; then
+        echo "Error: harness branch '${HARNESS_VALIDATE_BRANCH}' does not exist." >&2
+        exit 1
+    fi
+    echo "==> Validation mode: checking out ${HARNESS_VALIDATE_BRANCH}"
+    git checkout "${HARNESS_VALIDATE_BRANCH}"
+    HARNESS_MODE="validate"
+else
+    issue_num_for_label=$(grep -oE 'gh issue view [0-9]+' "$REPO_ROOT/.sandcastle/prompt.md" | head -1 | grep -oE '[0-9]+' || true)
+    if [ -n "$issue_num_for_label" ]; then
+        labels=$(gh issue view "$issue_num_for_label" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
+        if echo ",${labels}," | grep -q ',harness-change,'; then
+            HARNESS_HOLD_BRANCH="sandcastle-harness-pending-$(date +%Y%m%d-%H%M%S)"
+            HARNESS_MODE="hold"
+            export SANDCASTLE_HARNESS_PENDING_BRANCH="${HARNESS_HOLD_BRANCH}"
+            echo "==> Harness change detected (issue #${issue_num_for_label} labelled 'harness-change')."
+            echo "    main.ts will land work on holding branch: ${HARNESS_HOLD_BRANCH}"
+        fi
+    fi
+fi
+
+# ── Allow-list scope check ────────────────────────────────────────────────────
+# Parses `## Allowed paths` (fenced code block of glob patterns) from the
+# current issue's body and rejects diffs that touch files outside that list.
+# Issues filed before this convention was established have no section; we warn
+# and skip enforcement.
+
+issue_num=$(grep -oE 'gh issue view [0-9]+' "$REPO_ROOT/.sandcastle/prompt.md" | head -1 | grep -oE '[0-9]+' || true)
+
+if [ -z "$issue_num" ]; then
+    echo "==> Warning: could not determine issue number from prompt.md; allow-list check skipped." >&2
+else
+    gh label create sandcastle-failed --color "EE0000" --description "Sandcastle run reverted by host gate" 2>/dev/null || true
+    gh label create sandcastle-recovered --color "0E8A16" --description "Sandcastle backup branch manually recovered via recover.sh" 2>/dev/null || true
+
+    issue_body=$(gh issue view "$issue_num" --json body --jq '.body' 2>/dev/null || true)
+    issue_labels=$(gh issue view "$issue_num" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
+    case ",${issue_labels}," in
+        *,afk-ready,*) issue_is_afk_ready=1 ;;
+        *)             issue_is_afk_ready=0 ;;
+    esac
+
+    allowed_paths=$(printf '%s\n' "$issue_body" | awk '
+      /^## Allowed paths/ {found=1; capture=0; next}
+      /^## / {found=0; capture=0; next}
+      found && /^```/ {capture=!capture; next}
+      capture && NF > 0 {print}
+    ')
+
+    if [ -z "$allowed_paths" ]; then
+        if [ "$issue_is_afk_ready" = "1" ]; then
+            echo "!! Issue #${issue_num} is labelled 'afk-ready' but has no '## Allowed paths' section." >&2
+            echo "   The allow-list scope check cannot run without it. Refusing to merge." >&2
+            echo "   Fix: edit the issue body to add a fenced '## Allowed paths' block, then rerun." >&2
+            gate_revert_with_logs "sandcastle-failed-no-allowlist-${ts}"
+            post_revert_comment_and_label "$issue_num" "missing '## Allowed paths' section on afk-ready issue" "sandcastle-failed-no-allowlist-${ts}" "Add a fenced '## Allowed paths' block to the issue body, then re-run."
+            exit 1
+        fi
+        echo "==> Warning: issue #${issue_num} has no '## Allowed paths' section — scope check skipped." >&2
+        echo "    Add a fenced '## Allowed paths' block to the issue body to enforce scope on future runs." >&2
+    else
+        # Pre-flight: each literal path's parent directory must exist. The
+        # file itself may be new (slices that legitimately create files), but
+        # the directory anchor must be real — that catches typo'd paths before
+        # the run, while allowing genuinely new files inside existing directories.
+        preflight_violations=()
+        while IFS= read -r p; do
+            [ -z "$p" ] && continue
+            case "$p" in
+                *'*'*|*'?'*|*'['*) continue ;;
+            esac
+            parent_dir=$(dirname "$p")
+            if [ ! -d "$REPO_ROOT/$parent_dir" ]; then
+                preflight_violations+=("$p")
+            fi
+        done <<< "$allowed_paths"
+
+        if [ ${#preflight_violations[@]} -gt 0 ]; then
+            echo "!! Pre-flight: literal path(s) in '## Allowed paths' have non-existent parent directory:" >&2
+            for p in "${preflight_violations[@]}"; do
+                echo "     - $p (parent: $(dirname "$p")/)" >&2
+            done
+            gate_revert_with_logs "sandcastle-failed-preflight-${ts}"
+            post_revert_comment_and_label "$issue_num" "pre-flight: literal path(s) in allow-list have non-existent parent directory" "sandcastle-failed-preflight-${ts}" "$(printf 'Literal path(s) in ## Allowed paths whose parent directory does not exist:\n%s\n\nThe file may be new, but the directory must already exist. Fix the directory portion of the allow-list and re-run.' "$(for p in "${preflight_violations[@]}"; do echo "- \`$p\` (parent \`$(dirname "$p")/\` missing)"; done)")"
+            exit 1
+        fi
+
+        pathspec_args=()
+        while IFS= read -r p; do
+            [ -z "$p" ] && continue
+            pathspec_args+=(":(glob)$p")
+        done <<< "$allowed_paths"
+
+        # Auto-allow `.sandcastle/artifacts/<file>` for every filename declared
+        # in the issue's `## Required artifacts` block. The required-artifact
+        # gate below MANDATES the agent commit those files there; the allow-list
+        # gate must therefore whitelist them implicitly. Without this the two
+        # gates conflict — the agent ships exactly what was asked and gets
+        # reverted.
+        required_artifacts_for_allow=$(printf '%s\n' "$issue_body" | awk '
+          /^## Required artifacts/ {found=1; capture=0; next}
+          /^## / {found=0; capture=0; next}
+          found && /^```/ {capture=!capture; next}
+          capture && NF > 0 {print}
+        ')
+        while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            pathspec_args+=(":(glob).sandcastle/artifacts/$f")
+        done <<< "$required_artifacts_for_allow"
+
+        # Always-allowed auto-generated files. Tooling can regenerate certain
+        # files on every build (e.g. a router's route-tree file), so any slice
+        # that triggers a rebuild would trip the allow-list otherwise.
+        # Populate SANDCASTLE_AUTO_GENERATED_FILES in your .env as a
+        # space-separated list of repo-relative paths.
+        read -ra AUTO_GENERATED_ALLOWED <<< "${SANDCASTLE_AUTO_GENERATED_FILES:-}"
+        for f in "${AUTO_GENERATED_ALLOWED[@]}"; do
+            pathspec_args+=(":(glob)${f}")
+        done
+
+        all_changed=$(git diff --name-only "${DIFF_RANGE}" | sort -u)
+        allowed_changed=$(git diff --name-only "${DIFF_RANGE}" -- "${pathspec_args[@]}" | sort -u)
+        violations=$(comm -23 <(printf '%s\n' "$all_changed") <(printf '%s\n' "$allowed_changed"))
+
+        if [ -n "$violations" ]; then
+            echo
+            echo "!! Allow-list violation: agent edited files outside #${issue_num}'s declared scope. Capturing worktree logs before revert." >&2
+            echo "   Out-of-scope files:" >&2
+            printf '%s\n' "$violations" | sed 's/^/     - /' >&2
+            echo "   Allowed patterns:" >&2
+            printf '%s\n' "$allowed_paths" | sed 's/^/     /' >&2
+            echo
+
+            gate_revert_with_logs "sandcastle-failed-allowlist-${ts}"
+            post_revert_comment_and_label "$issue_num" "allow-list violation" "sandcastle-failed-allowlist-${ts}" "$(printf 'Out-of-scope files:\n%s' "$(printf '%s\n' "$violations" | sed 's/^/- /')")"
+            exit 1
+        fi
+
+        echo "==> Allow-list check passed (issue #${issue_num})."
+    fi
+fi

--- a/examples/bash-harness/run.sh
+++ b/examples/bash-harness/run.sh
@@ -68,36 +68,44 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
 fi
 
 
-# ── Harness lifecycle mode detection ─────────────────────────────────────────
-# Two scenarios:
-#   1. --harness-branch <name>: validation mode. Check out <name>, run agent
-#      against it; on success fast-forward main onto <name>.
-#   2. Issue labelled `harness-change`: hold mode. Land work on a holding
-#      branch instead of merging to main; operator validates later.
-HARNESS_HOLD_BRANCH=""
-HARNESS_MODE=""
+MAX_ATTEMPTS=3
+attempt=0
+while : ; do
+    attempt=$((attempt + 1))
+    echo "==> Attempt ${attempt}/${MAX_ATTEMPTS}: launching Sandcastle..."
+    set +e
+    npx tsx .sandcastle/main.ts
+    sandcastle_status=$?
+    set -e
 
-if [ -n "${HARNESS_VALIDATE_BRANCH}" ]; then
-    if ! git show-ref --verify --quiet "refs/heads/${HARNESS_VALIDATE_BRANCH}"; then
-        echo "Error: harness branch '${HARNESS_VALIDATE_BRANCH}' does not exist." >&2
-        exit 1
-    fi
-    echo "==> Validation mode: checking out ${HARNESS_VALIDATE_BRANCH}"
-    git checkout "${HARNESS_VALIDATE_BRANCH}"
-    HARNESS_MODE="validate"
-else
-    issue_num_for_label=$(grep -oE 'gh issue view [0-9]+' "$REPO_ROOT/.sandcastle/prompt.md" | head -1 | grep -oE '[0-9]+' || true)
-    if [ -n "$issue_num_for_label" ]; then
-        labels=$(gh issue view "$issue_num_for_label" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
-        if echo ",${labels}," | grep -q ',harness-change,'; then
-            HARNESS_HOLD_BRANCH="sandcastle-harness-pending-$(date +%Y%m%d-%H%M%S)"
-            HARNESS_MODE="hold"
-            export SANDCASTLE_HARNESS_PENDING_BRANCH="${HARNESS_HOLD_BRANCH}"
-            echo "==> Harness change detected (issue #${issue_num_for_label} labelled 'harness-change')."
-            echo "    main.ts will land work on holding branch: ${HARNESS_HOLD_BRANCH}"
+    after_head=$(git rev-parse HEAD)
+    if [ "${HARNESS_MODE}" = "hold" ]; then
+        if git show-ref --verify --quiet "refs/heads/${HARNESS_HOLD_BRANCH}" \
+            && [ "$(git rev-list "main..${HARNESS_HOLD_BRANCH}" --count 2>/dev/null || echo 0)" -gt 0 ]; then
+            break
+        fi
+    else
+        if [ "$after_head" != "$before_head" ]; then
+            break
         fi
     fi
-fi
+
+    latest_log=$(ls -t "$REPO_ROOT/.sandcastle/logs/"main-*.log 2>/dev/null | head -1)
+    if [ -n "$latest_log" ] && grep -q "<promise>BLOCKED</promise>" "$latest_log"; then
+        echo "==> Agent signaled BLOCKED — not retrying. See ${latest_log}."
+        exit 0
+    fi
+
+    if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+        echo "==> ${MAX_ATTEMPTS} attempts produced no commits and no BLOCKED signal. Giving up." >&2
+        echo "    Latest run log: ${latest_log:-<none>}" >&2
+        exit "${sandcastle_status:-1}"
+    fi
+
+    echo "==> Attempt ${attempt} produced no commits and no BLOCKED signal — likely a transient API/stream failure. Retrying."
+done
+
+ts=$(date +%Y%m%d-%H%M%S)
 
 # ── Allow-list scope check ────────────────────────────────────────────────────
 # Parses `## Allowed paths` (fenced code block of glob patterns) from the

--- a/examples/bash-harness/run.sh
+++ b/examples/bash-harness/run.sh
@@ -67,6 +67,100 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
     exit 1
 fi
 
+# ── Harness lifecycle mode detection ─────────────────────────────────────────
+# Two scenarios:
+#   1. --harness-branch <name>: validation mode. Check out <name>, run agent
+#      against it; on success fast-forward main onto <name>.
+#   2. Issue labelled `harness-change`: hold mode. Land work on a holding
+#      branch instead of merging to main; operator validates later.
+HARNESS_HOLD_BRANCH=""
+HARNESS_MODE=""
+
+if [ -n "${HARNESS_VALIDATE_BRANCH}" ]; then
+    if ! git show-ref --verify --quiet "refs/heads/${HARNESS_VALIDATE_BRANCH}"; then
+        echo "Error: harness branch '${HARNESS_VALIDATE_BRANCH}' does not exist." >&2
+        exit 1
+    fi
+    echo "==> Validation mode: checking out ${HARNESS_VALIDATE_BRANCH}"
+    git checkout "${HARNESS_VALIDATE_BRANCH}"
+    HARNESS_MODE="validate"
+else
+    issue_num_for_label=$(grep -oE 'gh issue view [0-9]+' "$REPO_ROOT/.sandcastle/prompt.md" | head -1 | grep -oE '[0-9]+' || true)
+    if [ -n "$issue_num_for_label" ]; then
+        labels=$(gh issue view "$issue_num_for_label" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
+        if echo ",${labels}," | grep -q ',harness-change,'; then
+            HARNESS_HOLD_BRANCH="sandcastle-harness-pending-$(date +%Y%m%d-%H%M%S)"
+            HARNESS_MODE="hold"
+            export SANDCASTLE_HARNESS_PENDING_BRANCH="${HARNESS_HOLD_BRANCH}"
+            echo "==> Harness change detected (issue #${issue_num_for_label} labelled 'harness-change')."
+            echo "    main.ts will land work on holding branch: ${HARNESS_HOLD_BRANCH}"
+        fi
+    fi
+fi
+
+# gate_revert_with_logs <backup-branch-name>
+#
+# Shared failure path used by every host gate (allow-list violation, missing
+# scope sections, missing artifact sections, missing artifact files,
+# test failure). Copies the agent worktree's .sandcastle/logs/ out to
+# the host (so they survive container teardown), parks the agent's commits
+# on the backup branch, and rewinds main (or restores main in validate
+# mode). Reads ts, REPO_ROOT, WORK_BRANCH, HARNESS_MODE, before_head,
+# after_head from the enclosing scope.
+gate_revert_with_logs() {
+    local backup_branch="$1"
+    local host_logs_out="${REPO_ROOT}/.sandcastle/logs/host-side-${ts}"
+    mkdir -p "${host_logs_out}"
+    local copied_any=0
+    while IFS= read -r wt; do
+      [ "$wt" = "$REPO_ROOT" ] && continue
+      if [ -d "${wt}/.sandcastle/logs" ]; then
+        cp -R "${wt}/.sandcastle/logs/." "${host_logs_out}/" 2>/dev/null || true
+        echo "   - Worktree logs copied from: ${wt}" >&2
+        copied_any=1
+      fi
+    done < <(git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}')
+    if [ "${copied_any}" = "0" ]; then
+      echo "   - No agent worktree with .sandcastle/logs found (Sandcastle may have already torn it down)." >&2
+    fi
+    if [ -n "${WORK_BRANCH}" ]; then
+        git branch -m "${WORK_BRANCH}" "${backup_branch}"
+        if [ "${HARNESS_MODE}" = "validate" ]; then
+            git checkout main
+        fi
+        echo "   - Failed commits preserved on branch: ${backup_branch}" >&2
+        echo "   - main unchanged at:                  $(git rev-parse --short main)" >&2
+    else
+        git branch "$backup_branch" "$after_head"
+        git reset --hard "$before_head"
+        echo "   - Failed commits preserved on branch: ${backup_branch}" >&2
+        echo "   - main reset to:                      ${before_head:0:10}" >&2
+    fi
+    echo "   To inspect: git log ${backup_branch}" >&2
+    echo "   To recover: git merge ${backup_branch}" >&2
+}
+
+# post_revert_comment_and_label <issue_num> <reason> <backup_branch> <details>
+#
+# Posts a structured diagnostic comment to the GitHub issue and applies the
+# sandcastle-failed label. Called from every revert site so failures are
+# visible on the issue timeline without digging through run logs.
+post_revert_comment_and_label() {
+    local issue_num="$1" reason="$2" backup_branch="$3" details="$4"
+    gh issue comment "$issue_num" --body "$(cat <<EOF
+❌ **Reverted by host gate**.
+**Reason**: $reason
+$details
+
+**Backup branch**: \`$backup_branch\`
+- Inspect: \`git log $backup_branch\`
+- Recover: \`./.sandcastle/recover.sh $backup_branch --note '<reason for override>'\`
+
+To re-run cleanly: fix the issue, then \`./.sandcastle/run.sh\`.
+EOF
+)" || true
+    gh issue edit "$issue_num" --add-label sandcastle-failed || true
+}
 
 MAX_ATTEMPTS=3
 attempt=0

--- a/examples/bash-harness/run.sh
+++ b/examples/bash-harness/run.sh
@@ -219,3 +219,65 @@ else
         echo "==> Allow-list check passed (issue #${issue_num})."
     fi
 fi
+
+# ── Required-artifact gate ────────────────────────────────────────────────────
+# Parses `## Required artifacts` (fenced code block of filenames, relative to
+# .sandcastle/artifacts/) from the current issue's body and rejects runs where
+# any declared artifact is missing or empty in the work-branch's git tree.
+# Issues without the section are skipped with a warning. Issues with an empty
+# section are skipped silently (templates seed the section empty by default).
+
+if [ -z "$issue_num" ]; then
+    : # already warned during allow-list parse
+elif [ -z "$issue_body" ]; then
+    : # already warned during allow-list parse
+else
+    section_present=$(printf '%s\n' "$issue_body" | grep -c '^## Required artifacts' || true)
+    required_artifacts=$(printf '%s\n' "$issue_body" | awk '
+      /^## Required artifacts/ {found=1; capture=0; next}
+      /^## / {found=0; capture=0; next}
+      found && /^```/ {capture=!capture; next}
+      capture && NF > 0 {print}
+    ')
+
+    if [ "$section_present" = "0" ]; then
+        if [ "$issue_is_afk_ready" = "1" ]; then
+            echo "!! Issue #${issue_num} is labelled 'afk-ready' but has no '## Required artifacts' section." >&2
+            echo "   The required-artifact gate cannot run without it. Refusing to merge." >&2
+            echo "   Fix: edit the issue body to add a fenced '## Required artifacts' block (empty fenced block is fine for issues with no fail-first ACs), then rerun." >&2
+            gate_revert_with_logs "sandcastle-failed-no-artifacts-${ts}"
+            post_revert_comment_and_label "$issue_num" "missing '## Required artifacts' section on afk-ready issue" "sandcastle-failed-no-artifacts-${ts}" "Add a fenced '## Required artifacts' block (empty fenced block is fine if there are no fail-first ACs), then re-run."
+            exit 1
+        fi
+        echo "==> Warning: issue #${issue_num} has no '## Required artifacts' section — artifact check skipped." >&2
+        echo "    Add a fenced '## Required artifacts' block to enforce evidence on future runs." >&2
+    elif [ -z "$required_artifacts" ]; then
+        : # section present but empty body — silent skip
+    else
+        missing_artifacts=()
+        while IFS= read -r artifact_name; do
+            [ -z "$artifact_name" ] && continue
+            artifact_path=".sandcastle/artifacts/${artifact_name}"
+            obj_type=$(git cat-file -t "${WORK_HEAD}:${artifact_path}" 2>/dev/null || echo missing)
+            blob_size=$(git cat-file -s "${WORK_HEAD}:${artifact_path}" 2>/dev/null || echo 0)
+            if [ "${obj_type}" != "blob" ] || [ "${blob_size}" -eq 0 ]; then
+                missing_artifacts+=("${artifact_name}")
+            fi
+        done <<< "$required_artifacts"
+
+        if [ ${#missing_artifacts[@]} -gt 0 ]; then
+            echo
+            echo "!! Required-artifact gate FAILED: agent did not commit non-empty evidence for #${issue_num}. Capturing worktree logs before revert." >&2
+            echo "   Missing or empty (under .sandcastle/artifacts/):" >&2
+            printf '     - %s\n' "${missing_artifacts[@]}" >&2
+            echo
+
+            gate_revert_with_logs "sandcastle-failed-artifacts-${ts}"
+            post_revert_comment_and_label "$issue_num" "missing required artifacts" "sandcastle-failed-artifacts-${ts}" "$(printf 'Missing or empty under .sandcastle/artifacts/:\n%s' "$(printf '- %s\n' "${missing_artifacts[@]}")")"
+            exit 1
+        fi
+
+        artifact_count=$(printf '%s\n' "$required_artifacts" | grep -c .)
+        echo "==> Required-artifact gate passed (issue #${issue_num}, ${artifact_count} declared)."
+    fi
+fi

--- a/examples/bash-harness/run.sh
+++ b/examples/bash-harness/run.sh
@@ -201,6 +201,46 @@ done
 
 ts=$(date +%Y%m%d-%H%M%S)
 
+# Pick the work branch tip that holds Sandcastle's commits, depending on the
+# harness lifecycle mode. In hold mode main HEAD never moved; in validate
+# mode we are checked out on the validate branch and Sandcastle's
+# merge-to-head landed work onto it.
+case "${HARNESS_MODE}" in
+    hold)
+        WORK_BRANCH="${HARNESS_HOLD_BRANCH}"
+        WORK_HEAD=$(git rev-parse "${HARNESS_HOLD_BRANCH}")
+        ;;
+    validate)
+        WORK_BRANCH="${HARNESS_VALIDATE_BRANCH}"
+        WORK_HEAD="${after_head}"
+        ;;
+    *)
+        # If main advanced during the agent's run (operator committed in
+        # parallel), Sandcastle's merge-to-head creates a merge commit
+        # whose second parent is the agent's branch tip. Diffing the
+        # merge commit against before_head sweeps the operator's commits
+        # into the agent's allow-list check and reverts legit work.
+        # Use the agent branch tip directly so concurrent main activity
+        # stays out of scope.
+        if agent_tip=$(git rev-parse --verify "${after_head}^2" 2>/dev/null); then
+            WORK_HEAD="${agent_tip}"
+        else
+            WORK_HEAD="${after_head}"
+        fi
+        WORK_BRANCH=""
+        ;;
+esac
+
+# Diff against the merge-base, not the launcher's pre-run snapshot, so that
+# concurrent commits to the launcher's base branch during the run don't end
+# up in the diff range. The merge-base is where the agent's branch diverged
+# from the base — exactly what scopes the agent's actual edits.
+diff_base=$(git merge-base "${before_head}" "${WORK_HEAD}")
+DIFF_RANGE="${diff_base}..${WORK_HEAD}"
+
+new_commits=$(git rev-list "${DIFF_RANGE}" --count)
+echo "==> Sandcastle produced ${new_commits} commit(s) (${DIFF_RANGE}). Running host gates..."
+
 # ── Allow-list scope check ────────────────────────────────────────────────────
 # Parses `## Allowed paths` (fenced code block of glob patterns) from the
 # current issue's body and rejects diffs that touch files outside that list.

--- a/examples/bash-harness/run.sh
+++ b/examples/bash-harness/run.sh
@@ -281,3 +281,75 @@ else
         echo "==> Required-artifact gate passed (issue #${issue_num}, ${artifact_count} declared)."
     fi
 fi
+
+# ── Host test gate ────────────────────────────────────────────────────────────
+# Loads PROJECT_TEST_CMD from .env at repo root (or inherits from environment)
+# and runs the project's test suite on the host against the merged commit(s).
+# On failure: preserve the agent's commits on a backup branch, reset main.
+
+if [ -f "$REPO_ROOT/.env" ]; then
+    set -o allexport
+    source "$REPO_ROOT/.env"
+    set +o allexport
+fi
+
+if [ -z "${PROJECT_TEST_CMD:-}" ]; then
+    echo "Error: PROJECT_TEST_CMD is not set." >&2
+    echo "       Set it in $REPO_ROOT/.env or export it before running run.sh." >&2
+    exit 1
+fi
+
+host_log="$REPO_ROOT/.sandcastle/logs/host-test-${ts}.log"
+mkdir -p "$(dirname "$host_log")"
+
+set +e
+eval "${PROJECT_TEST_CMD}" 2>&1 | tee "$host_log"
+test_status=${PIPESTATUS[0]}
+set -e
+
+if [ "$test_status" -eq 0 ]; then
+    case "${HARNESS_MODE}" in
+        hold)
+            echo
+            echo "============================================================="
+            echo "==> Harness change HELD on branch: ${HARNESS_HOLD_BRANCH}"
+            echo "    main HEAD unchanged: $(git rev-parse --short main)"
+            echo
+            echo "    To validate this harness change:"
+            echo "        ./.sandcastle/run.sh --harness-branch ${HARNESS_HOLD_BRANCH}"
+            echo
+            echo "    First retarget .sandcastle/prompt.md at a benign feature issue."
+            echo "    Successful validation fast-forwards main onto the held branch"
+            echo "    (both harness change and validation feature work)."
+            echo "    NOTE: if your harness change touched .sandcastle/Dockerfile,"
+            echo "    rebuild the image first or the validation runs against stale state."
+            echo "============================================================="
+            exit 0
+            ;;
+        validate)
+            echo "==> Validation gates passed. Fast-forwarding main onto ${HARNESS_VALIDATE_BRANCH}."
+            git checkout main
+            git merge --ff-only "${HARNESS_VALIDATE_BRANCH}"
+            git branch -D "${HARNESS_VALIDATE_BRANCH}"
+            echo "==> main is now at: $(git rev-parse --short HEAD). Run complete."
+            exit 0
+            ;;
+        *)
+            echo "==> Host tests passed. Run complete."
+            if [ -n "$issue_num" ]; then
+                gh issue close "$issue_num" --comment "Closed by Sandcastle: $(git rev-parse HEAD)" || true
+            fi
+            exit 0
+            ;;
+    esac
+fi
+
+echo
+echo "!! Host tests FAILED on the merged commit(s). Capturing worktree logs before revert." >&2
+backup_branch="sandcastle-failed-${ts}"
+gate_revert_with_logs "${backup_branch}"
+echo "   - Test log: ${host_log}" >&2
+if [ -n "$issue_num" ]; then
+    post_revert_comment_and_label "$issue_num" "host tests failed" "$backup_branch" "Test log: \`.sandcastle/logs/$(basename "$host_log")\`"
+fi
+exit 1


### PR DESCRIPTION
## Summary

Adds a complete bash-based operator harness reference implementation and a production operator guide.

- **`examples/bash-harness/`** — copy-paste harness for any project: `run.sh`, `recover.sh`, `queue.sh`, `Dockerfile`, `claude-shim.sh`, `mcp-settings.json`, `.env.example`
- **`OPERATOR.md`** — full operator guide covering OAuth setup, allow-list gate, required-artifacts gate, two-phase harness lifecycle, failure recovery, batch queue, and orchestrator turn-end discipline

## Overlap evaluation (v0.5.4 → v0.5.7)

No semantic conflicts. Matt's 0.5.5–0.5.7 changes are all library-internal. Rebased cleanly on top of `upstream/main` (0.5.7) with zero conflicts.

## Upstream-candidate issues

Each commit in this branch has a corresponding `upstream-pr-candidate` issue in this fork describing the feature and drafting the upstream PR. See the `upstream-pr-candidate` label.

## Provenance

These scripts were developed as the operator harness for a real production project (autotax) running Sandcastle over ~80 AFK issues since April 2026. The generalised versions here strip all project-specific content.